### PR TITLE
ubihealthd: turn scrub_peb() into a NOP

### DIFF
--- a/ubi-utils/ubihealthd.c
+++ b/ubi-utils/ubihealthd.c
@@ -318,6 +318,7 @@ static int read_peb(int fd, struct peb_info *peb)
 
 static int scrub_peb(int fd, struct peb_info *peb)
 {
+	/*
 	time_t now = time(NULL);
 	log_debug("Scrubbing PEB %"PRIu64, peb->peb_num);
 	int err = ioctl (fd, UBI_IOCSPEB, &peb->peb_num);
@@ -326,6 +327,7 @@ static int scrub_peb(int fd, struct peb_info *peb)
 		return -1;
 	}
 	peb->last_read = now;
+	*/
 	return 0;
 }
 


### PR DESCRIPTION
Explicit PEB scrubbing is not required, simply reading the PEB should
schedule scrubbing if needed.

This hack just turns the scrub_peb() into a NOP. The proper fix would
be to apply the latest ubihealthd patches (from Daniel), where the
functionality has been dropped. But I don't want to take the risk,
hence the dirty hack for now.

Signed-off-by: Boris Brezillon <boris.brezillon@free-electrons.com>